### PR TITLE
Create jitpack.yml to use JDK11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Allows jitpack to build and host your artifact, which should get around issues with #16 and eliminate the need for you to host the maven.

You can see the repo on jitpack at https://jitpack.io/#PseudoResonance/Pixy2JavaAPI, notice that the build is failing because it defaults to Java 8- this PR changes the version to Java 11 for successful compilation (this [build log](https://jitpack.io/com/github/democat3457/Pixy2JavaAPI/patch-1-1091c888cd-1/build.log) of the branch shows that it will successfully compile)